### PR TITLE
Refactor requirements, make plex optional

### DIFF
--- a/CommercialBreaker.py
+++ b/CommercialBreaker.py
@@ -1,9 +1,16 @@
 import tkinter as tk
 from ComBreak.CommercialBreakerGUI import CommercialBreakerGUI
-from config import *
+import config
 
-if __name__ == "__main__":
+
+def main():
     root = tk.Tk()
-    root.iconbitmap(icon_path)
+    try:
+        root.iconbitmap(config.icon_path)
+    except Exception as ex:
+        print(f'Error showing icon: {ex!r}')
     app = CommercialBreakerGUI(root)
     root.mainloop()
+
+if __name__ == "__main__":
+    main()

--- a/TOM.py
+++ b/TOM.py
@@ -1,13 +1,14 @@
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
-import ttkthemes as ttkthemes
+# import ttkthemes as ttkthemes
 import sv_ttk
 from ComBreak.CommercialBreakerLogic import CommercialBreakerLogic
 from FrontEndLogic import LogicController
-from config import *
+import config
 import threading
 import os
 import psutil
+
 
 class Page1(ttk.Frame):
     def __init__(self, parent, controller, logic):
@@ -79,7 +80,7 @@ class Page1(ttk.Frame):
         # Create the 'Continue' button but don't pack it yet
         self.continue_button = ttk.Button(button_frame, text="Continue",
                                         command=self.on_continue_button_click)
-  
+
     def update_dropdown(self):
         """Callback to update the dropdown when new server choices are announced."""
         self.plex_server_dropdown['values'] = self.logic.plex_servers
@@ -98,7 +99,7 @@ class Page1(ttk.Frame):
         if self.libraries_selected == 2:
             self.skip_button.pack_forget()
             self.continue_button.pack(side="right", padx=5, pady=5)
-    
+
 
     def add_1_to_libraries_selected(self, event):
         self.libraries_selected += 1
@@ -119,7 +120,7 @@ class Page2(ttk.Frame):
         self.controller = controller
         label = ttk.Label(self, text="Enter your details:", font=("Helvetica", 24))
         label.pack(pady=10, padx=10)
-        
+
         # Pass both the instance of Page2 and the main controller (MainApplication) to LogicController
         self.logic = logic
 
@@ -171,7 +172,7 @@ class Page2(ttk.Frame):
         dizquetv_url = self.dizquetv_url_entry.get()
         self.logic.on_continue_second(plex_url, plex_token, selected_anime_library, selected_toonami_library, dizquetv_url)
         self.controller.show_frame("Page3")
-        
+
 
 class Page3(ttk.Frame):
     def __init__(self, parent, controller, logic):
@@ -184,7 +185,7 @@ class Page3(ttk.Frame):
 
         self.anime_folder_entry = ttk.Entry(self)
         self.anime_folder_entry.pack(pady=3)
-        anime_button = ttk.Button(self, text="Browse Anime Folder", 
+        anime_button = ttk.Button(self, text="Browse Anime Folder",
                                  command=lambda: self.anime_folder_entry.insert(0, filedialog.askdirectory()))
         anime_button.pack(pady=3)
 
@@ -248,7 +249,7 @@ class Page4(ttk.Frame):
         get_plex_timestamps_button = ttk.Button(self, text="Get Plex Timestamps",
                                         command=self.logic.get_plex_timestamps)
         get_plex_timestamps_button.pack(pady=3)
-        
+
         # Create a new frame to hold the button
         button_frame = ttk.Frame(self)
         button_frame.pack(side="bottom", anchor="se", fill="x")
@@ -320,7 +321,7 @@ class Page5(ttk.Frame):
         self.create_widgets()
 
     def tkraise(self):
-        main_app = self.controller
+        # main_app = self.controller
         working_folder = self.TOM_logic._get_data("working_folder")
         cut_folder = working_folder + "/cut"
         toonami_filtered_folder = working_folder + "/toonami_filtered"
@@ -331,7 +332,7 @@ class Page5(ttk.Frame):
         # Call the original tkraise method to display the frame
         super().tkraise()
 
-    
+
     def create_widgets(self):
         """Create the widgets for the GUI."""
         # Create a new frame to hold the checkboxes
@@ -453,14 +454,14 @@ class Page5(ttk.Frame):
         """Exit the program."""
         main_process_pid = os.getpid() # Get the PID of the main process
         main_process = psutil.Process(main_process_pid)
-        
+
         # Iterate through child processes and terminate them
         for child_process in main_process.children(recursive=True):
             try:
                 child_process.terminate()
             except:
                 pass # Handle exceptions as needed
-        
+
         os._exit(0)
 
     def update_progress(self, current, total):
@@ -573,7 +574,7 @@ class Page7(ttk.Frame):
         what_toonami_version_label.pack(pady=3)
 
         toonami_version_dropdown = ttk.Combobox(self, textvariable=self.toonami_version)
-        toonami_version_dropdown['values'] = list(TOONAMI_CONFIG.keys())
+        toonami_version_dropdown['values'] = list(config.TOONAMI_CONFIG.keys())
         toonami_version_dropdown.pack(pady=3)
 
         channel_number_label = ttk.Label(self, text="What channel number do you want to use?")
@@ -670,7 +671,7 @@ class Page8(ttk.Frame):
         dizquetv_channel_number = self.dizquetv_channel_number_entry.get()
         dizquetv_flex_duration = self.dizquetv_flex_duration_entry.get()
         self.logic.add_flex_creds(ssh_host, ssh_user, ssh_pass, dizquetv_docker_name, dizquetv_channel_number, dizquetv_flex_duration)
-        self.logic.add_flex()        
+        self.logic.add_flex()
 
 
 
@@ -696,7 +697,7 @@ class MainApplication(tk.Tk):
 
 
         self.show_frame("Page1")
-        
+
     def set_theme(self):
         if self.dark_mode:
             sv_ttk.set_theme("dark")
@@ -719,12 +720,20 @@ class MainApplication(tk.Tk):
             "Page7": "Step 6 - Let's Make Another Channel! - Toonami's Back Bitches",
             "Page8": "Step 7 - Flex Your Toonami Channel - Commerecial Break"
         }
-        
+
         frame = self.frames[page_name]
         frame.tkraise()
         self.title(frame_titles[page_name])
 
-if __name__ == "__main__":
+
+def main():
     app = MainApplication()
-    app.iconbitmap(icon_path)
+    try:
+        app.iconbitmap(config.icon_path)
+    except Exception as ex:
+        print(f'Error showing icon: {ex!r}')
     app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/ToonamiTools/GetTimestampPlex.py
+++ b/ToonamiTools/GetTimestampPlex.py
@@ -1,8 +1,8 @@
-from plexapi.server import PlexServer
 import os
 
 class GetPlexTimestamps:
     def __init__(self, plex_url, plex_token, library_name, save_dir):
+        from plexapi.server import PlexServer
         self.plex = PlexServer(plex_url, plex_token)
         self.library_name = library_name
         self.save_dir = save_dir

--- a/ToonamiTools/LoginToPlex.py
+++ b/ToonamiTools/LoginToPlex.py
@@ -1,8 +1,5 @@
 import asyncio
-from plexauth import PlexAuth
-from plexapi.myplex import MyPlexAccount
-from plexapi.server import PlexServer
-import webbrowser 
+import webbrowser
 
 class PlexServerList:
     def __init__(self):
@@ -10,6 +7,7 @@ class PlexServerList:
         self.plex_token = None
 
     def GetPlexToken(self):
+        from plexauth import PlexAuth
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
@@ -34,6 +32,7 @@ class PlexServerList:
         loop.close()
 
     def GetPlexServerList(self):
+        from plexapi.myplex import MyPlexAccount
         self.GetPlexToken()
         try:
             account = MyPlexAccount(token=self.plex_token)
@@ -52,6 +51,7 @@ class PlexLibraryManager:
         self.plex_url = None
 
     def GetPlexDetails(self):
+        from plexapi.myplex import MyPlexAccount
         account = MyPlexAccount(token=self.plex_token)
         selected_resource = next(resource for resource in account.resources() if resource.name == self.selected_server)
         plex = selected_resource.connect()
@@ -67,6 +67,7 @@ class PlexLibraryFetcher:
         self.libraries = []
 
     def GetPlexLibraries(self):
+        from plexapi.server import PlexServer
         server = PlexServer(self.plex_url, self.plex_token)
         libraries = server.library.sections()
         self.libraries = [library.title for library in libraries]

--- a/ToonamiTools/LoginToPlex.py
+++ b/ToonamiTools/LoginToPlex.py
@@ -1,5 +1,9 @@
 import asyncio
 import webbrowser
+from plexauth import PlexAuth
+from plexapi.myplex import MyPlexAccount
+from plexapi.server import PlexServer
+
 
 class PlexServerList:
     def __init__(self):
@@ -7,7 +11,6 @@ class PlexServerList:
         self.plex_token = None
 
     def GetPlexToken(self):
-        from plexauth import PlexAuth
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
@@ -32,7 +35,6 @@ class PlexServerList:
         loop.close()
 
     def GetPlexServerList(self):
-        from plexapi.myplex import MyPlexAccount
         self.GetPlexToken()
         try:
             account = MyPlexAccount(token=self.plex_token)
@@ -51,7 +53,6 @@ class PlexLibraryManager:
         self.plex_url = None
 
     def GetPlexDetails(self):
-        from plexapi.myplex import MyPlexAccount
         account = MyPlexAccount(token=self.plex_token)
         selected_resource = next(resource for resource in account.resources() if resource.name == self.selected_server)
         plex = selected_resource.connect()
@@ -67,7 +68,6 @@ class PlexLibraryFetcher:
         self.libraries = []
 
     def GetPlexLibraries(self):
-        from plexapi.server import PlexServer
         server = PlexServer(self.plex_url, self.plex_token)
         libraries = server.library.sections()
         self.libraries = [library.title for library in libraries]

--- a/ToonamiTools/PlexToDizqueTV.py
+++ b/ToonamiTools/PlexToDizqueTV.py
@@ -1,12 +1,13 @@
 import pandas as pd
 import sqlite3
 import re
+from plexapi.server import PlexServer
+from dizqueTV import API
+
 
 class PlexToDizqueTVSimplified:
     def __init__(self, plex_url, plex_token, library_name, table, dizquetv_url, channel_number):
         print("Initializing the connection to Plex and dizqueTV...")
-        from plexapi.server import PlexServer
-        from dizqueTV import API
         self.plex = PlexServer(plex_url, plex_token)
         self.library_name = library_name
         self.dtv = API(url=dizquetv_url)

--- a/ToonamiTools/PlexToDizqueTV.py
+++ b/ToonamiTools/PlexToDizqueTV.py
@@ -1,12 +1,12 @@
-from plexapi.server import PlexServer
 import pandas as pd
-from dizqueTV import API
 import sqlite3
 import re
 
 class PlexToDizqueTVSimplified:
     def __init__(self, plex_url, plex_token, library_name, table, dizquetv_url, channel_number):
         print("Initializing the connection to Plex and dizqueTV...")
+        from plexapi.server import PlexServer
+        from dizqueTV import API
         self.plex = PlexServer(plex_url, plex_token)
         self.library_name = library_name
         self.dtv = API(url=dizquetv_url)
@@ -21,33 +21,33 @@ class PlexToDizqueTVSimplified:
 
     def run(self):
         print("Fetching media items from Plex and SQLite DB...")
-        
+
         # Step 1: Fetch media items from Plex and SQLite DB
         df = self.df
         all_media = self.plex.library.section(self.library_name).all()
-        
+
         media_dict = {self.get_filename_from_path(media.media[0].parts[0].file): media for media in all_media}
         file_paths = df['FULL_FILE_PATH'].tolist()
         file_names = [self.get_filename_from_path(path) for path in file_paths]
-        
+
         playlist_media = [media_dict[file_name] for file_name in file_names if file_name in media_dict]
-        
+
         print(f"Identified {len(playlist_media)} media items to add to the dizqueTV channel.")
-        
+
         print("Checking and updating the dizqueTV channel...")
         # Step 2: Add those media items to dizqueTV channel
         channel = self.dtv.get_channel(self.channel_number)
         if not channel:
             print("Channel not found. Creating a new one...")
             channel = self.dtv.add_channel(programs=[], name=self.library_name, number=self.channel_number)
-        
+
         to_add = []
         for item in playlist_media:
             print(f"Converting Plex item: {item.title}")
             program = self.dtv.convert_plex_item_to_program(plex_item=item, plex_server=self.plex)
             if program:
                 to_add.append(program)
-        
+
         print("Deleting old programs from the channel...")
         if channel.delete_all_programs():
             print("Adding new programs to the channel...")

--- a/ToonamiTools/RenameSplitPlex.py
+++ b/ToonamiTools/RenameSplitPlex.py
@@ -1,8 +1,8 @@
 import re
-from plexapi.server import PlexServer
 
 class PlexLibraryUpdater:
     def __init__(self, plex_url, plex_token, library_name):
+        from plexapi.server import PlexServer
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.library_name = library_name
@@ -14,17 +14,17 @@ class PlexLibraryUpdater:
         # Iterate through all the videos in the library
         for video in self.library.all():
             file_path = video.media[0].parts[0].file
-            
+
             # Apply the regex pattern to extract the file name
             match = re.search(self.pattern, file_path)
             if match:
                 new_title = match.group(1)
-                
+
                 # Check if the title already matches the target title
                 if video.title == new_title:
                     print(f"Title already matches for file: {file_path}. Skipping.")
                     continue
-                
+
                 # Rename the video title
                 video.edit(**{'title.value': new_title, 'title.locked': 1})
                 print(f"Title updated to: {new_title}")

--- a/ToonamiTools/RenameSplitPlex.py
+++ b/ToonamiTools/RenameSplitPlex.py
@@ -1,8 +1,9 @@
 import re
+from plexapi.server import PlexServer
+
 
 class PlexLibraryUpdater:
     def __init__(self, plex_url, plex_token, library_name):
-        from plexapi.server import PlexServer
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.library_name = library_name

--- a/ToonamiTools/plexautosplitter.py
+++ b/ToonamiTools/plexautosplitter.py
@@ -1,11 +1,11 @@
 import uuid
-from plexapi.server import PlexServer
 
 class PlexAutoSplitter:
     def __init__(self, plex_url, plex_token, library_name):
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.library_name = library_name
+        from plexapi.server import PlexServer
         self.plex = PlexServer(self.plex_url, self.plex_token)
 
     def split_merged_item(self, rating_key):

--- a/ToonamiTools/plexautosplitter.py
+++ b/ToonamiTools/plexautosplitter.py
@@ -1,11 +1,12 @@
 import uuid
+from plexapi.server import PlexServer
+
 
 class PlexAutoSplitter:
     def __init__(self, plex_url, plex_token, library_name):
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.library_name = library_name
-        from plexapi.server import PlexServer
         self.plex = PlexServer(self.plex_url, self.plex_token)
 
     def split_merged_item(self, rating_key):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,3 @@
-pandas==1.5.3
-python-Levenshtein
-ffmpeg
-opencv-python
-numpy
-regex
-shutilwhich
-requests
-beautifulsoup4
-fuzzywuzzy
-xlsxwriter
-openpyxl
-dizquetv
-plexapi
-psutil
-plexapi
-plexauth
-sv_ttk
-ttkthemes
-unidecode
-opencv-python
+-r requirements/runtime.txt
+-r requirements/graphics.txt
+-r requirements/optional.txt

--- a/requirements/graphics.txt
+++ b/requirements/graphics.txt
@@ -1,0 +1,11 @@
+# xdev availpkg opencv-python-headless
+# --prefer-binary
+opencv-python>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
+opencv-python>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
+opencv-python>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8
+opencv-python>=3.4.15.55  ; python_version < '3.8' and python_version >= '3.7'    # Python 3.7
+opencv-python>=3.4.13.47  ; python_version < '3.7' and python_version >= '3.6'    # Python 3.6
+opencv-python>=3.1.0.2   ; python_version < '3.6' and python_version >= '3.5'    # Python 3.5
+opencv-python>=3.1.0.5   ; python_version < '3.5' and python_version >= '3.4'    # Python 3.4
+opencv-python>=3.1.0.0   ; python_version < '3.4' and python_version >= '2.7'    # Python 2.7

--- a/requirements/headless.txt
+++ b/requirements/headless.txt
@@ -1,0 +1,11 @@
+# xdev availpkg opencv-python-headless
+# --prefer-binary
+opencv-python-headless>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python-headless>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
+opencv-python-headless>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
+opencv-python-headless>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8
+opencv-python-headless>=3.4.15.55  ; python_version < '3.8' and python_version >= '3.7'    # Python 3.7
+opencv-python-headless>=3.4.13.47  ; python_version < '3.7' and python_version >= '3.6'    # Python 3.6
+opencv-python-headless>=3.4.2.16  ; python_version < '3.6' and python_version >= '3.5'    # Python 3.5
+opencv-python-headless>=3.4.2.16  ; python_version < '3.5' and python_version >= '3.4'    # Python 3.4
+opencv-python-headless>=3.4.2.16  ; python_version < '3.4' and python_version >= '2.7'    # Python 2.7

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,0 +1,3 @@
+plexapi>=4.15.5
+plexauth>=0.0.6
+dizquetv>=1.5.0.9

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,13 @@
+pandas==1.5.3
+levenshtein>=0.21.1
+numpy>=1.26.1
+requests>=2.28.2
+beautifulsoup4>=4.12.0
+fuzzywuzzy>=0.18.0
+xlsxwriter>=3.1.9
+openpyxl>=3.1.2
+psutil>5.9.4
+sv_ttk>=2.5.5
+ttkthemes>=3.2.2
+unidecode>=1.3.7
+# ffmpeg is this used?

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,10 @@
+pytest>=6.2.5            ;                               python_version >= '3.10.0'  # Python 3.10+
+pytest>=4.6.0            ; python_version < '3.10.0' and python_version >= '3.7.0'   # Python 3.7-3.9
+
+pytest-cov>=3.0.0           ;                               python_version >= '3.6.0'   # Python 3.6+
+
+pytest-timeout>=1.4.2
+
+coverage>=6.1.1     ;                            python_version >= '3.10'    # Python 3.10+
+coverage>=5.3.1     ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
+coverage>=6.1.1     ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8


### PR DESCRIPTION
This is a small refactor that does the following:

* my editor did remove a lot of extra whitespace, but if that's a problem I can undo that
* Explicitly import config instead of using `import *` in some places
* Move plex imports into the functions they are used so they can be an optional component of the system
* On Linux the icons were breaking for me, so I put a try/except around them.
* Refactor the requirements. This is the biggest change, so I'll explain it in a sepate paragraph.


The refactor to requirements breaks the single file into multiple parts. It splits plex and other components into an optional.txt. Most of the core requirements are added to runtime.txt, and lastly opencv is a strange package to work with. There is a headless and non-headless version and for application compatibility you generally don't want to list it as a hard requirement, but you also want to give the user the option of working with either. Towards this end, there is a graphics.txt and headless.txt. The regular requirements.txt points to graphics.txt. (Even though I think headless is a better default I wanted this PR to have no functionality changes, so that maintains previous behavior). Lastly, each requirement is given a minimum version, which is important for package deployment / reproducibility, as well as integration with other refactors I could help contribute to this repo. 

