### PR TITLE
Remove import *

### DIFF
--- a/FrontEndLogic.py
+++ b/FrontEndLogic.py
@@ -1,6 +1,7 @@
 import sqlite3
-from ToonamiTools import *
-from config import *
+import ToonamiTools
+import config
+
 
 class LogicController():
     def __init__(self):
@@ -8,7 +9,7 @@ class LogicController():
         self._setup_database()
         self._new_server_choice_subscribers = []
         self._new_library_choice_subscribers = []
-        self.plex_servers = [] 
+        self.plex_servers = []
         self.plex_libraries = []
 
     def _setup_database(self):
@@ -21,7 +22,7 @@ class LogicController():
                 )
             """)
             conn.commit()
-            
+
     def _set_data(self, key, value):
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
@@ -37,11 +38,11 @@ class LogicController():
             cursor.execute("SELECT value FROM app_data WHERE key = ?", (key,))
             result = cursor.fetchone()
             return result[0] if result else None
-        
+
     def subscribe_to_new_server_choices(self, callback):
         if callable(callback):
             self._new_server_choice_subscribers.append(callback)
-    
+
     def subscribe_to_new_library_choices(self, callback):
         if callable(callback):
             self._new_library_choice_subscribers.append(callback)
@@ -49,7 +50,7 @@ class LogicController():
     def login_to_plex(self):
         try:
             # Create PlexServerList instance, fetch token and populate dropdown
-            self.server_list = PlexServerList()
+            self.server_list = ToonamiTools.PlexServerList()
             self.server_list.run()
 
             # Update the list of servers
@@ -68,10 +69,10 @@ class LogicController():
     def fetch_libraries(self, selected_server):
         try:
             # Create PlexLibraryManager and PlexLibraryFetcher instances
-            self.library_manager = PlexLibraryManager(selected_server, self.server_list.plex_token)
+            self.library_manager = ToonamiTools.PlexLibraryManager(selected_server, self.server_list.plex_token)
             self.library_manager.run()
 
-            self.library_fetcher = PlexLibraryFetcher(self.library_manager.plex_url, self.server_list.plex_token)
+            self.library_fetcher = ToonamiTools.PlexLibraryFetcher(self.library_manager.plex_url, self.server_list.plex_token)
             self.library_fetcher.run()
 
             # Update the list of libraries
@@ -81,92 +82,89 @@ class LogicController():
             for subscriber in self._new_library_choice_subscribers:
                 subscriber()
 
-
         except Exception as e:  # Replace with more specific exceptions if known
             print(f"An error occurred while fetching libraries: {e}")
 
     def on_continue_first(self, selected_anime_library, selected_toonami_library, dizquetv_url):
         # Use the database value if the widget value starts with "eg. ", otherwise use the widget value
 
-        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library == None:
+        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library is None:
             selected_anime_library = self._get_data("selected_anime_library")
-        
-        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library == None:
+
+        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library is None:
             selected_toonami_library = self._get_data("selected_toonami_library")
 
-        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url == None:
+        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url is None:
             dizquetv_url = self._get_data("dizquetv_url")
-        
+
         plex_url = self.library_manager.plex_url
-        if plex_url.startswith("eg. ") or not plex_url or plex_url == None:
+        if plex_url.startswith("eg. ") or not plex_url or plex_url is None:
             plex_url = self._get_data("plex_url")
-        
+
         plex_token = self.library_manager.plex_token
-        if plex_token.startswith("eg. ") or not plex_token or plex_token == None:
+        if plex_token.startswith("eg. ") or not plex_token or plex_token is None:
             plex_token = self._get_data("plex_token")
-        
+
         # Save the fetched data to the database
         self._set_data("selected_anime_library", selected_anime_library)
         self._set_data("selected_toonami_library", selected_toonami_library)
         self._set_data("plex_url", plex_url)
         self._set_data("plex_token", plex_token)
         self._set_data("dizquetv_url", dizquetv_url)
-        
+
         # Optional: Print values for verification
         print(selected_anime_library, selected_toonami_library, plex_url, plex_token, dizquetv_url)
-
 
     def on_continue_second(self, selected_anime_library, selected_toonami_library, plex_url, plex_token, dizquetv_url):
         # Check each widget value, if it starts with "eg. ", fetch the value from the database
 
-        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library == None:
+        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library is None:
             selected_anime_library = self._get_data("selected_anime_library")
-        
-        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library == None:
+
+        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library is None:
             selected_toonami_library = self._get_data("selected_toonami_library")
-        
-        if plex_url.startswith("eg. ") or not plex_url or plex_url == None:
+
+        if plex_url.startswith("eg. ") or not plex_url or plex_url is None:
             plex_url = self._get_data("plex_url")
 
-        if plex_token.startswith("eg. ") or not plex_token or plex_token == None:
+        if plex_token.startswith("eg. ") or not plex_token or plex_token is None:
             plex_token = self._get_data("plex_token")
-        
-        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url == None:
+
+        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url is None:
             dizquetv_url = self._get_data("dizquetv_url")
-        
+
         # Save the fetched data to the database
         self._set_data("selected_anime_library", selected_anime_library)
         self._set_data("selected_toonami_library", selected_toonami_library)
         self._set_data("plex_url", plex_url)
         self._set_data("plex_token", plex_token)
         self._set_data("dizquetv_url", dizquetv_url)
-        
+
         # Optional: Print values for verification
         print(selected_anime_library, selected_toonami_library, plex_url, plex_token, dizquetv_url)
 
     def on_continue_third(self, anime_folder, bump_folder, special_bump_folder, working_folder):
         # Check each widget value, if it's blank, fetch the value from the database
-        if not anime_folder or anime_folder == None:
+        if not anime_folder or anime_folder is None:
             anime_folder = self._get_data("anime_folder")
-        
-        if not bump_folder or bump_folder == None:
+
+        if not bump_folder or bump_folder is None:
             bump_folder = self._get_data("bump_folder")
-        
-        if not special_bump_folder or special_bump_folder == None:
+
+        if not special_bump_folder or special_bump_folder is None:
             special_bump_folder = self._get_data("special_bump_folder")
-        
-        if not working_folder or working_folder == None:
+
+        if not working_folder or working_folder is None:
             working_folder = self._get_data("working_folder")
-        
+
         # Save the fetched data to the database
         self._set_data("anime_folder", anime_folder)
         self._set_data("bump_folder", bump_folder)
         self._set_data("special_bump_folder", special_bump_folder)
         self._set_data("working_folder", working_folder)
-        
+
         # Optional: Print values for verification
         print(anime_folder, bump_folder, special_bump_folder, working_folder)
-
 
     def prepare_content(self, dont_move, display_show_selection):
         # Update the values based on the current state of the checkboxes
@@ -174,7 +172,7 @@ class LogicController():
         working_folder = self._get_data("working_folder")
         anime_folder = self._get_data("anime_folder")
         bump_folder = self._get_data("bump_folder")
-        toonami_folder = working_folder + "/toonami" 
+        toonami_folder = working_folder + "/toonami"
         nice_bumps = working_folder + "/nice_bumps"
         merger_bumps_list_1 = 'multibumps_v2_data_reordered'
         merger_bumps_list_2 = 'multibumps_v3_data_reordered'
@@ -186,15 +184,15 @@ class LogicController():
         merger_out_4 = 'lineup_v8_uncut'
         uncut_encoder_out = 'uncut_encoded_data'
         filter_output_folder = working_folder + "/toonami_filtered/"
-        fmaker = FolderMaker(working_folder)
-        easy_checker = ToonamiChecker(anime_folder)
-        easy_mover = FileMover(toonami_folder, self.dont_move)
-        lineup_prep = MediaProcessor(bump_folder, nice_bumps)
-        easy_encoder = ToonamiEncoder()
-        uncutencoder = UncutEncoder(toonami_folder)
-        ml = Multilineup()
-        merger = ShowScheduler(uncut=True)
-        fmove = FilterAndMove()
+        fmaker = ToonamiTools.FolderMaker(working_folder)
+        easy_checker = ToonamiTools.ToonamiChecker(anime_folder)
+        easy_mover = ToonamiTools.FileMover(toonami_folder, self.dont_move)
+        lineup_prep = ToonamiTools.MediaProcessor(bump_folder, nice_bumps)
+        easy_encoder = ToonamiTools.ToonamiEncoder()
+        uncutencoder = ToonamiTools.UncutEncoder(toonami_folder)
+        ml = ToonamiTools.Multilineup()
+        merger = ToonamiTools.ShowScheduler(uncut=True)
+        fmove = ToonamiTools.FilterAndMove()
         fmaker.run()
         unique_show_names, toonami_episodes = easy_checker.prepare_episode_data()
         selected_shows = display_show_selection(unique_show_names)
@@ -216,9 +214,8 @@ class LogicController():
         plex_ts_url = self._get_data("plex_url")
         plex_ts_token = self._get_data("plex_token")
         plex_ts_anime_library_name = self._get_data("selected_anime_library")
-        GetTimestamps = GetPlexTimestamps(plex_ts_url, plex_ts_token, plex_ts_anime_library_name, toonami_filtered_folder)
-        GetTimestamps.run() # Calling the run method on the instance
-
+        GetTimestamps = ToonamiTools.GetPlexTimestamps(plex_ts_url, plex_ts_token, plex_ts_anime_library_name, toonami_filtered_folder)
+        GetTimestamps.run()  # Calling the run method on the instance
 
     def prepare_cut_anime(self):
         working_folder = self._get_data("working_folder")
@@ -232,10 +229,10 @@ class LogicController():
         merger_out_4 = 'lineup_v8'
         commercial_injector_out = 'commercial_injector_final'
         cut_folder = working_folder + "/cut"
-        commercial_injector_prep = AnimeFileOrganizer(cut_folder)
-        commercial_injector = LineupLogic()
-        BIC = BlockIDCreator()
-        merger = ShowScheduler(apply_ns3_logic=True)
+        commercial_injector_prep = ToonamiTools.AnimeFileOrganizer(cut_folder)
+        commercial_injector = ToonamiTools.LineupLogic()
+        BIC = ToonamiTools.BlockIDCreator()
+        merger = ToonamiTools.ShowScheduler(apply_ns3_logic=True)
         commercial_injector_prep.organize_files()
         commercial_injector.generate_lineup()
         BIC.run()
@@ -246,53 +243,51 @@ class LogicController():
 
     def add_special_bumps(self):
         special_bump_folder = self._get_data("special_bump_folder")
-        sepcial_bump_processor = FileProcessor(special_bump_folder)
+        sepcial_bump_processor = ToonamiTools.FileProcessor(special_bump_folder)
         sepcial_bump_processor.process_files()
 
     def create_prepare_plex(self):
         plex_url_plex_splitter = self._get_data("plex_url")
         plex_token_plex_splitter = self._get_data("plex_token")
         plex_library_name_plex_splitter = self._get_data("selected_toonami_library")
-        plex_splitter = PlexAutoSplitter(plex_url_plex_splitter, plex_token_plex_splitter, plex_library_name_plex_splitter)
+        plex_splitter = ToonamiTools.PlexAutoSplitter(plex_url_plex_splitter, plex_token_plex_splitter, plex_library_name_plex_splitter)
         plex_splitter.split_merged_items()
-        plex_rename_split = PlexLibraryUpdater(plex_url_plex_splitter, plex_token_plex_splitter, plex_library_name_plex_splitter)
+        plex_rename_split = ToonamiTools.PlexLibraryUpdater(plex_url_plex_splitter, plex_token_plex_splitter, plex_library_name_plex_splitter)
         plex_rename_split.update_titles()
 
     def create_toonami_channel(self, toonami_version, channel_number):
         plex_url = self._get_data("plex_url")
         plex_token = self._get_data("plex_token")
         plex_library_name = self._get_data("selected_toonami_library")
-        config = TOONAMI_CONFIG.get(toonami_version, {})
-        table = config["table"]
+        toon_config = config.TOONAMI_CONFIG.get(toonami_version, {})
+        table = toon_config["table"]
         dizquetv_url = self._get_data("dizquetv_url")
-        ptod = PlexToDizqueTVSimplified(plex_url, plex_token, plex_library_name, table, dizquetv_url, channel_number)
+        ptod = ToonamiTools.PlexToDizqueTVSimplified(plex_url, plex_token, plex_library_name, table, dizquetv_url, channel_number)
         ptod.run()
-
 
     def prepare_toonami_channel(self, start_from_last_episode, toonami_version):
 
-        config = TOONAMI_CONFIG_CONT.get(toonami_version, {})
+        cont_config = ToonamiTools.TOONAMI_CONFIG_CONT.get(toonami_version, {})
 
-        merger_bump_list = config["merger_bump_list"]
-        merger_out = config["merger_out"]
-        encoder_in = config["encoder_in"]
-        uncut = config["uncut"]
+        merger_bump_list = cont_config["merger_bump_list"]
+        merger_out = cont_config["merger_out"]
+        encoder_in = cont_config["encoder_in"]
+        uncut = cont_config["uncut"]
 
-        merger = ShowScheduler(reuse_episode_blocks=True, continue_from_last_used_episode_block=start_from_last_episode, uncut=uncut)
+        merger = ToonamiTools.ShowScheduler(reuse_episode_blocks=True, continue_from_last_used_episode_block=start_from_last_episode, uncut=uncut)
         merger.run(merger_bump_list, encoder_in, merger_out)
 
     def create_toonami_channel_cont(self, toonami_version, channel_number):
 
-        config = TOONAMI_CONFIG_CONT.get(toonami_version, {})
-        table = config["merger_out"]
+        cont_config = ToonamiTools.TOONAMI_CONFIG_CONT.get(toonami_version, {})
+        table = cont_config["merger_out"]
         dizquetv_url = self._get_data("dizquetv_url")
         plex_url = self._get_data("plex_url")
         plex_token = self._get_data("plex_token")
         plex_library_name = self._get_data("selected_toonami_library")
 
-        ptod = PlexToDizqueTVSimplified(plex_url, plex_token, plex_library_name, table, dizquetv_url, channel_number)
+        ptod = ToonamiTools.PlexToDizqueTVSimplified(plex_url, plex_token, plex_library_name, table, dizquetv_url, channel_number)
         ptod.run()
-
 
     def add_flex_creds(self, ssh_host, ssh_user, ssh_pass, dizquetv_container_name, dizquetv_channel_number, dizquetv_flex_duration):
         # Attempt to retrieve data from the database
@@ -324,5 +319,5 @@ class LogicController():
         dizquetv_container_name = self._get_data("dizquetv_container_name")
         dizquetv_channel_number = self._get_data("dizquetv_channel_number")
         dizquetv_flex_duration = self._get_data("dizquetv_flex_duration")
-        Flex = DizqueTVManager(ssh_host, ssh_user, ssh_pass, dizquetv_container_name, dizquetv_channel_number, dizquetv_flex_duration)
+        Flex = ToonamiTools.DizqueTVManager(ssh_host, ssh_user, ssh_pass, dizquetv_container_name, dizquetv_channel_number, dizquetv_flex_duration)
         Flex.main()

--- a/FrontEndLogic.py
+++ b/FrontEndLogic.py
@@ -88,21 +88,21 @@ class LogicController():
     def on_continue_first(self, selected_anime_library, selected_toonami_library, dizquetv_url):
         # Use the database value if the widget value starts with "eg. ", otherwise use the widget value
 
-        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library is None:
+        if selected_anime_library.startswith("eg. ") or not selected_anime_library:
             selected_anime_library = self._get_data("selected_anime_library")
 
-        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library is None:
+        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library:
             selected_toonami_library = self._get_data("selected_toonami_library")
 
-        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url is None:
+        if dizquetv_url.startswith("eg. ") or not dizquetv_url:
             dizquetv_url = self._get_data("dizquetv_url")
 
         plex_url = self.library_manager.plex_url
-        if plex_url.startswith("eg. ") or not plex_url or plex_url is None:
+        if plex_url.startswith("eg. ") or not plex_url:
             plex_url = self._get_data("plex_url")
 
         plex_token = self.library_manager.plex_token
-        if plex_token.startswith("eg. ") or not plex_token or plex_token is None:
+        if plex_token.startswith("eg. ") or not plex_token:
             plex_token = self._get_data("plex_token")
 
         # Save the fetched data to the database
@@ -118,19 +118,19 @@ class LogicController():
     def on_continue_second(self, selected_anime_library, selected_toonami_library, plex_url, plex_token, dizquetv_url):
         # Check each widget value, if it starts with "eg. ", fetch the value from the database
 
-        if selected_anime_library.startswith("eg. ") or not selected_anime_library or selected_anime_library is None:
+        if selected_anime_library.startswith("eg. ") or not selected_anime_library:
             selected_anime_library = self._get_data("selected_anime_library")
 
-        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library or selected_toonami_library is None:
+        if selected_toonami_library.startswith("eg. ") or not selected_toonami_library:
             selected_toonami_library = self._get_data("selected_toonami_library")
 
-        if plex_url.startswith("eg. ") or not plex_url or plex_url is None:
+        if plex_url.startswith("eg. ") or not plex_url:
             plex_url = self._get_data("plex_url")
 
-        if plex_token.startswith("eg. ") or not plex_token or plex_token is None:
+        if plex_token.startswith("eg. ") or not plex_token:
             plex_token = self._get_data("plex_token")
 
-        if dizquetv_url.startswith("eg. ") or not dizquetv_url or dizquetv_url is None:
+        if dizquetv_url.startswith("eg. ") or not dizquetv_url:
             dizquetv_url = self._get_data("dizquetv_url")
 
         # Save the fetched data to the database
@@ -145,16 +145,16 @@ class LogicController():
 
     def on_continue_third(self, anime_folder, bump_folder, special_bump_folder, working_folder):
         # Check each widget value, if it's blank, fetch the value from the database
-        if not anime_folder or anime_folder is None:
+        if not anime_folder:
             anime_folder = self._get_data("anime_folder")
 
-        if not bump_folder or bump_folder is None:
+        if not bump_folder:
             bump_folder = self._get_data("bump_folder")
 
-        if not special_bump_folder or special_bump_folder is None:
+        if not special_bump_folder:
             special_bump_folder = self._get_data("special_bump_folder")
 
-        if not working_folder or working_folder is None:
+        if not working_folder:
             working_folder = self._get_data("working_folder")
 
         # Save the fetched data to the database


### PR DESCRIPTION
Another import * I missed, or perhaps it was updated after my previous PR.

Additionally I was going to change comparisons to None, from `... == None` to `... is None`, which is [generally standard practice](https://stackoverflow.com/questions/3257919/what-is-the-difference-between-is-none-and-none) when comparing to None (note: you still want to use `==` almost everywhere else). However, I noticed that the places it was written were effectively redundant. 

E.g. 

```
if not anime_folder or anime_folder is None:
    ...
```

The `not anime_folder` resolves to `True` if `anime_folder = None`, so the second check never executes and can just be removed.